### PR TITLE
SEO fixes for MetaTitle and MetaDescription

### DIFF
--- a/Constants/SEOConstants.cs
+++ b/Constants/SEOConstants.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace DotNetNuke.Modules.ActiveForums.Constants
+{
+    public static class SEOConstants
+    {
+        public const int MaxMetaTitleLength = 65;
+        public const int MaxMetaDescriptionLength = 150;
+    }
+}

--- a/CustomControls/UserControls/TopicView.cs
+++ b/CustomControls/UserControls/TopicView.cs
@@ -28,6 +28,7 @@ using System.Web.UI;
 using System.Web.UI.WebControls;
 using System.Text.RegularExpressions;
 using System.Xml;
+using DotNetNuke.Modules.ActiveForums.Constants;
 
 namespace DotNetNuke.Modules.ActiveForums.Controls
 {
@@ -583,7 +584,9 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 MetaTemplate = MetaTemplate.Replace("[BODY]", _topicDescription);
 
                 MetaTitle = TemplateUtils.GetTemplateSection(MetaTemplate, "[TITLE]", "[/TITLE]").Replace("[TITLE]", string.Empty).Replace("[/TITLE]", string.Empty);
+                MetaTitle = MetaTitle.TruncateAtWord(SEOConstants.MaxMetaTitleLength);
                 MetaDescription = TemplateUtils.GetTemplateSection(MetaTemplate, "[DESCRIPTION]", "[/DESCRIPTION]").Replace("[DESCRIPTION]", string.Empty).Replace("[/DESCRIPTION]", string.Empty);
+                MetaDescription = MetaDescription.TruncateAtWord(SEOConstants.MaxMetaDescriptionLength);
                 MetaKeywords = TemplateUtils.GetTemplateSection(MetaTemplate, "[KEYWORDS]", "[/KEYWORDS]").Replace("[KEYWORDS]", string.Empty).Replace("[/KEYWORDS]", string.Empty);
             }
 

--- a/CustomControls/UserControls/TopicsView.cs
+++ b/CustomControls/UserControls/TopicsView.cs
@@ -29,6 +29,7 @@ using System.Web.UI;
 using System.Web.UI.WebControls;
 using System.Text.RegularExpressions;
 using System.Xml;
+using DotNetNuke.Modules.ActiveForums.Constants;
 
 namespace DotNetNuke.Modules.ActiveForums.Controls
 {
@@ -355,7 +356,9 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                                 MetaTemplate = MetaTemplate.Replace("[BODY]", Utilities.StripHTMLTag(ForumInfo.ForumDesc));
 
                                 MetaTitle = TemplateUtils.GetTemplateSection(MetaTemplate, "[TITLE]", "[/TITLE]").Replace("[TITLE]", string.Empty).Replace("[/TITLE]", string.Empty);
+                                MetaTitle = MetaTitle.TruncateAtWord(SEOConstants.MaxMetaTitleLength);
                                 MetaDescription = TemplateUtils.GetTemplateSection(MetaTemplate, "[DESCRIPTION]", "[/DESCRIPTION]").Replace("[DESCRIPTION]", string.Empty).Replace("[/DESCRIPTION]", string.Empty);
+                                MetaDescription = MetaDescription.TruncateAtWord(SEOConstants.MaxMetaDescriptionLength);
                                 MetaKeywords = TemplateUtils.GetTemplateSection(MetaTemplate, "[KEYWORDS]", "[/KEYWORDS]").Replace("[KEYWORDS]", string.Empty).Replace("[/KEYWORDS]", string.Empty);
                             }
                             BindTopics(TopicsTemplate);

--- a/class/StringExtensions.cs
+++ b/class/StringExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace DotNetNuke.Modules.ActiveForums
+{
+	public static class StringExtensions
+	{
+        public static string TruncateAtWord(this string value, int length)
+        {
+            if (String.IsNullOrEmpty(value) || value.Length < length)
+                return value;
+            int iNextSpace = value.LastIndexOf(" ", length);
+            return string.Format("{0}", value.Substring(0, (iNextSpace > 0) ? iNextSpace : length).Trim());
+        }
+	}
+}


### PR DESCRIPTION
When running SEO analysis (using the microsoft SEO optimisation toolkit or other tools)  on a site with active forums, this come up a lot (for nearly every topic).

For SEO purposes

MetaTitle should not exceed 65 characters.
MetaDescription should not exceed 150 characters.

This pull request truncates the MetaTitle and MetaDescription at the last whole word before the max length. Not sure if this is the best option, I thought about using an elipse (...) but that would probably mess up SEO just as much.
