### PR TITLE
Fixing issue #132 default attachment setting for allowed file type is wrong

### DIFF
--- a/class/ForumsConfig.cs
+++ b/class/ForumsConfig.cs
@@ -212,7 +212,7 @@ namespace DotNetNuke.Modules.ActiveForums
 						Settings.SaveSetting(ModuleId, sKey, ForumSettingKeys.AllowAttach, "true");
 						Settings.SaveSetting(ModuleId, sKey, ForumSettingKeys.AttachCount, "3");
 						Settings.SaveSetting(ModuleId, sKey, ForumSettingKeys.AttachMaxSize, "1000");
-						Settings.SaveSetting(ModuleId, sKey, ForumSettingKeys.AttachTypeAllowed, ".jpg,.png,.gif,.zip");
+						Settings.SaveSetting(ModuleId, sKey, ForumSettingKeys.AttachTypeAllowed, "txt,tiff,pdf,xls,xlsx,doc,docx,ppt,pptx");
 						//Settings.SaveSetting(ModuleId, sKey, ForumSettingKeys.AttachStore, "FILESYSTEM");
 						Settings.SaveSetting(ModuleId, sKey, ForumSettingKeys.AttachMaxHeight, "450");
 						Settings.SaveSetting(ModuleId, sKey, ForumSettingKeys.AttachMaxWidth, "450");


### PR DESCRIPTION
The old attachment type allowed list was incorrect.  It included the decimal point which is incorrect.  Changing the list to documents only and correcting the mistake.
