### PR TITLE
Update jquery.afFileUpload.js file extension handling

### DIFF
--- a/scripts/jquery.afFileUpload.js
+++ b/scripts/jquery.afFileUpload.js
@@ -73,9 +73,9 @@
                     
                     if(opts.allowedFileTypes) {
                         var fileName = data.originalFiles[0].name;
-                        var fileExtension = fileName.substr((~-fileName.lastIndexOf(".") >>> 0) + 2);
+                        var fileExtension = fileName.substr((~-fileName.lastIndexOf(".") >>> 0) + 2).toLowerCase();
 
-                        var acceptableFileExtensions = opts.allowedFileTypes.toLowerCase().replace(' ', '').replace('.', '').split(',');
+                        var acceptableFileExtensions = opts.allowedFileTypes.toLowerCase().replace(' ', '').replace(/\./g, '').split(',');
 
                         if ($.inArray(fileExtension, acceptableFileExtensions) === -1) {
                             uploadErrors.push(opts.fileTypeNotAllowedMsg);


### PR DESCRIPTION
- comparison of file extensions needs to be case-insensitive
- remove dots from acceptable file extensions prior to comparing to extension of file being uploaded (which doesn't have a dot)
