### PR TITLE
Update 06.01.03.SqlDataProvider

### DIFF
--- a/sql/06.01.03.SqlDataProvider
+++ b/sql/06.01.03.SqlDataProvider
@@ -102,7 +102,7 @@ FROM
 					  {databaseOwner}{objectQualifier}vw_activeforums_GroupForum AS v ON FT.ForumId = v.ForumId INNER JOIN
 					  {databaseOwner}{objectQualifier}vw_activeforums_ForumTopics AS T ON FT.TopicId = T.TopicId LEFT OUTER JOIN
 					  {databaseOwner}{objectQualifier}vw_activeforums_ForumReplies AS R ON FT.LastReplyId = R.ReplyId AND FT.LastReplyId IS NOT NULL LEFT OUTER JOIN
-					  {databaseOwner}{objectQualifier}activeforums_Poll ON T.TopicId = {databaseOwner}activeforums_Poll.TopicId
+					  {databaseOwner}{objectQualifier}activeforums_Poll ON T.TopicId = {databaseOwner}{objectQualifier}activeforums_Poll.TopicId
 WHERE     (v.ForumActive = 1) AND (v.ModuleId = @ModuleId) AND (v.ForumId = @ForumId) AND (FT.TopicId = @TopicId)
 END
 --Forum Security


### PR DESCRIPTION
line 105 is missing an {objectQualifier} which causes the script to fail during install if you have a qualifier set in DNN (eg- 'dnn_' which is the default in 7.3.4)