### PR TITLE
Update ForumView.txt

### DIFF
--- a/config/templates/ForumView.txt
+++ b/config/templates/ForumView.txt
@@ -32,7 +32,7 @@
 						
 					[FORUMS]
 					<tr>
-						<td colspan="0">
+						<td colspan="4">
 							 <table class="afgrid" cellspacing="0" cellpadding="0" width="100%">
 								<tr>
 									<td class="aftopicrow af-icons">[FORUMICONCSS]</td>


### PR DESCRIPTION
In IE 9, first topic in a forum group is not aligned properly. In order to resolve this the colspan should be 4.

![activeforum home](https://cloud.githubusercontent.com/assets/14235953/9854540/da73486a-5b26-11e5-8c88-846a4a755633.png)
