### PR TITLE
Update TopicsView.txt

### DIFF
--- a/config/templates/TopicsView.txt
+++ b/config/templates/TopicsView.txt
@@ -149,10 +149,10 @@
 						[TOPICS]
 						
 						<tr>
-							<td class="[ROWCSS] af-posticon">[POSTICON]</td>
 							<td class="[ROWCSS] af-content af-postcontent">
 								<table width="100%">
 									<tr>
+									<td  rowspan="2" style="padding-top:5px; padding-right:7px;" class="[ROWCSS] af-posticon">[POSTICON]</td>
 										<td rowspan="2" class="afsubject" title="[BODYTITLE]">
 										
 										<span class="afhiddenstats">[REPLIES] [RESX:REPLIESHEADER] and [VIEWS] [RESX:Views]</span>


### PR DESCRIPTION
To fix the alignment of Topics in IE 9.

![topics](https://cloud.githubusercontent.com/assets/14235953/9883002/5bf6a444-5bf5-11e5-9b46-b629ec473b25.png)
