### PR TITLE
Updates to try to prevent MOVE settings from firing if database connection lost

### DIFF
--- a/ActiveForums.dnn
+++ b/ActiveForums.dnn
@@ -1,6 +1,6 @@
 ﻿<dotnetnuke type="Package" version="5.0">
     <packages>
-        <package name="Active Forums" type="Module" version="06.03.03">
+        <package name="Active Forums" type="Module" version="06.03.04">
             <friendlyName>Active Forums</friendlyName>
             <description>Active Forums - Forum module for DotNetNuke</description>
             <iconFile>DesktopModules/ActiveForums/images/af6_icon.jpg</iconFile>
@@ -334,7 +334,7 @@
                 </component>
             </components>
         </package>
-      <package name="Active Forums What's New" type="Module" version="06.03.03">
+      <package name="Active Forums What's New" type="Module" version="06.03.04">
         <friendlyName>Active Forums What's New</friendlyName>
         <foldername>ActiveForumsWhatsNew</foldername>
         <description>Display the most recent topics or replies from selected forums on any page within your site.</description>

--- a/Documentation/ReleaseNotes.txt
+++ b/Documentation/ReleaseNotes.txt
@@ -8,7 +8,15 @@ Active Forums is an award winning, DotNetNuke module that allows you to easily b
 
     <hr />
 	</div>
-    <h3>Release Notes</h3>
+
+
+<h3>Release Notes</h3>
+<b>Version 06.03.04</b>
+<ul>
+	<li>#432 Attempted fix for losing INSTALLDATE</li>
+<ul>
+
+<h3>Release Notes</h3>
 <b>Version 06.03.03</b>
 <ul>
 	<li>Changed deprecated APIs.</li>

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 //
 // Active Forums - http://activeforums.org
-// Copyright (c) 2015
+// Copyright (c) 2015-2019
 // by Active Forums Community
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
@@ -35,7 +35,7 @@ using System.Security;
 [assembly: AssemblyDescription("Discussion Forum Module for DotNetNuke")]
 [assembly: AssemblyCompany("activeforums.org")]
 [assembly: AssemblyProduct("Active Forums")]
-[assembly: AssemblyCopyright("Copyright © 2004-2018 activeforums.org")]
+[assembly: AssemblyCopyright("Copyright © 2004-2019 activeforums.org")]
 [assembly: AssemblyTrademark("")]
 
 
@@ -52,9 +52,9 @@ using System.Security;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 
-[assembly: AssemblyVersion("06.03.03")]
+[assembly: AssemblyVersion("06.03.04")]
 
-[assembly: AssemblyFileVersion("06.03.03")]
+[assembly: AssemblyFileVersion("06.03.04")]
 [assembly: WebResource("DotNetNuke.Modules.ActiveForums.CustomControls.Resources.cb.js", "text/javascript")]
 [assembly: WebResource("DotNetNuke.Modules.ActiveForums.scripts.afadmin.properties.js", "text/javascript")]
 

--- a/class/Settings.cs
+++ b/class/Settings.cs
@@ -130,7 +130,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
         public bool NeedsConversion
         {
-            get { return MainSettings.GetBoolean("NeedsConvert", true); }
+            get { return MainSettings.GetBoolean("NeedsConvert", false); }
         }
 
         public PMTypes PMType


### PR DESCRIPTION
Updates to try to prevent MOVE settings from firing if database connection somehow fails, causing things like INSTALLDATE to be reset and forums to be inaccessible #432


Updated the DNN file and version numbers to make a clean build.