### PR TITLE
Fixes #437

### DIFF
--- a/class/Utilities.cs
+++ b/class/Utilities.cs
@@ -430,7 +430,14 @@ namespace DotNetNuke.Modules.ActiveForums
                 foreach (Match m in Regex.Matches(text, encodedHref, RegexOptions.IgnoreCase))
                     text = text.Replace(m.Value, HttpUtility.HtmlDecode(m.Value));
 
-               // Handle Empty string
+                const string regHref = "<a.*?href=[\"'](?<url>.*?)[\"'].*?>(?<http>http[s]?.*?)</a>";
+
+                // Remove all exiting <A> anchors, so they will be treated by the ReplaceLink function. (adding target=_blank & nofollow)
+                foreach (Match m in Regex.Matches(text, regHref, RegexOptions.IgnoreCase))
+                    text = text.Replace(m.Value, m.Groups["http"].Value.Contains("...") ? m.Groups["url"].Value : m.Groups["http"].Value);
+
+
+                // Handle Empty string
                 if (string.IsNullOrEmpty(text))
                 {
                     return original;

--- a/class/Utilities.cs
+++ b/class/Utilities.cs
@@ -424,26 +424,33 @@ namespace DotNetNuke.Modules.ActiveForums
             var original = text;
             if (!(string.IsNullOrEmpty(text)))
             {
-                const string encodedHref = "&lt;a.*?href=[\"'](?<url>.*?)[\"'].*?&gt;(http.*?)&lt;/a&gt;";
-                const string regHref = "<a.*?href=[\"'](?<url>.*?)[\"'].*?>(?<http>http.*?)</a>";
+                const string encodedHref = "&lt;a.*?href=[\"'](?<url>.*?)[\"'].*?&gt;(http[s]?.*?)&lt;/a&gt;"; // Encoded href regex
 
+                // Replace encoded url with decoded url
                 foreach (Match m in Regex.Matches(text, encodedHref, RegexOptions.IgnoreCase))
                     text = text.Replace(m.Value, HttpUtility.HtmlDecode(m.Value));
 
-                foreach (Match m in Regex.Matches(text, regHref, RegexOptions.IgnoreCase))
-                    text = text.Replace(m.Value, m.Groups["http"].Value.Contains("...") ? m.Groups["url"].Value : m.Groups["http"].Value);
-
+               // Handle Empty string
                 if (string.IsNullOrEmpty(text))
                 {
                     return original;
                 }
 
-                text = Regex.Replace(text, @"http://([\w+?\.\w+])+([a-zA-Z0-9\~\!\@\\#\$\%\^\&amp;\*\(\)_\-\=\+\\\/\?\.\:\;\'\,]*)?", m => ReplaceLink(m, currentSite, text), RegexOptions.IgnoreCase);
+                // Look for http(s) URLs  that are not perceded by a quote or <a>.
+                String strRegexUrl = @"(?<!['""]+|<a.*?>\s*)http[s]?://([\w+?\.\w+])+([a-zA-Z0-9\~\!\@\\#\$\%\^\&amp;\*\(\)_\-\=\+\\\/\?\.\:\;\'\,]*)?";
+
+                // Create auto link
+                text = Regex.Replace(text, strRegexUrl, m => ReplaceLink(m, currentSite, text), RegexOptions.IgnoreCase);
+
+
                 if (string.IsNullOrEmpty(text))
                 {
                     return original;
                 }
             }
+
+            Console.WriteLine("End:" + text + "\n");
+
             return text;
         }
 

--- a/class/Utilities.cs
+++ b/class/Utilities.cs
@@ -449,7 +449,6 @@ namespace DotNetNuke.Modules.ActiveForums
                 }
             }
 
-            Console.WriteLine("End:" + text + "\n");
 
             return text;
         }


### PR DESCRIPTION
A. I changed the Regex's to include https,  

B. I added a negative look behind to the check for urls to "autolink", based on https(s) not being preceded by a ",' or <a>

FYI, this look behind will fail is someone inserts a quote before the url BTW (in that the url will not be auto injected). But I think that's an edge case.

With the negative look behind the second check could be removed (line 433)